### PR TITLE
fix(variables): fix invalid validation error for schedule_state

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -67,7 +67,7 @@ variable "schedule_state" {
   default     = "DISABLED"
   validation {
     condition     = var.schedule_state == "ENABLED" || var.schedule_state == "DISABLED"
-    error_message = "Schedule state must be 'ENABLED' or 'DISABLED'"
+    error_message = "Schedule state must be 'ENABLED' or 'DISABLED'."
   }
 }
 


### PR DESCRIPTION
* Fix invalid validation error when running terraform init by updating error message to be written in english prose

This should fix https://github.com/port-labs/template-assets/issues/86